### PR TITLE
Peaks with Area=0 or  Spectrums with Intensity=0 errors

### DIFF
--- a/GCMSalign.py
+++ b/GCMSalign.py
@@ -32,6 +32,8 @@ from pyms.Display.Class import *
 
 import multiprocessing as mp
 
+from numba import jit #JT - jit test
+
 #window = 9  # width of window over which local ion maxima are detected
 #scans = 3  # distance at which locally apexing ions can be combined into one peak
 #n = 4  # min number of ions with intensity above a threshold
@@ -48,6 +50,7 @@ outdir = ""
 exprdir = ""
 
 # this is the peak detection only pipeline
+@jit
 def detect(args):
 
     # define path to data files
@@ -73,6 +76,7 @@ def detect(args):
 
 # loop over all runs and store the peaks as 'experiments'
 # within replicates alignment parameters
+@jit
 def detect_peaks(runs, args):
     expr_list = []
     pl_list = []
@@ -108,7 +112,7 @@ def detect_peaks(runs, args):
 
     return expr_list
 
-
+@jit
 def detect_one_run(run, args):
     infile = os.path.join(args.indir, run)
     print "processing GC-MS file:", infile
@@ -140,6 +144,7 @@ def detect_one_run(run, args):
 
 
 # this is the alignment-only pipeline
+@jit
 def align(args):
     global exprdir
     exprdir = args.exprdir
@@ -152,6 +157,7 @@ def align(args):
 
 
 # this is the full pipeline
+@jit
 def detect_and_align(args, chunked=False, numchunks=1):
 
     # define path to data files
@@ -186,6 +192,7 @@ window (default=7), while high complexity in data requires a higher order polyno
 
 The Durbin-Watson Classifier in OpenChrom can be used to determine the best width and order to use. A DW of 2.0 is optimal
 """
+@jit
 def call_peaks(im, tic, smooth, args):
     print "calling peaks"
     if smooth:
@@ -239,6 +246,7 @@ def call_peaks(im, tic, smooth, args):
     return pl3
 
 # creates an Experiment from a GCMS run and  writes it to a .expr file
+@jit
 def store_as_expr(run, peak_list, args):
     # create an experiment
     print "creating expression file for run ",run
@@ -253,7 +261,7 @@ def store_as_expr(run, peak_list, args):
 
     return expr
 
-
+@jit
 def load_expr_list_from_runlist(runs):
     el = []
     for run in runs:
@@ -263,7 +271,7 @@ def load_expr_list_from_runlist(runs):
 
     return el
 
-
+@jit
 def load_expr_list():
     # loads expr list from a directory of exprs
     global exprdir
@@ -278,7 +286,7 @@ def load_expr_list():
 
 
 
-
+@jit
 def load_run(infile):
 
     try:
@@ -301,6 +309,7 @@ def load_run(infile):
         # return build_intensity_matrix(data), tic
 
 # takes a list of Experiment objects and does a pairwise alignment. Optionally writes RTs, Areas and Ions to file.
+@jit
 def multi_align_local(exprlist, Dw, Gw, min_common=1, tofile=True, transposed=True):
     global exprdir
     global outdir
@@ -325,6 +334,7 @@ def multi_align_local(exprlist, Dw, Gw, min_common=1, tofile=True, transposed=Tr
 
 
 # takes a list of local alignments and aligns them globally
+@jit
 def multi_align_global(alignments_list, Db, Gb, min_common=1, tofile=True):
     print "globally aligning local alignments from list: ", alignments_list
     T1 = PairwiseAlignment(alignments_list, Db, Gb)
@@ -336,7 +346,7 @@ def multi_align_global(alignments_list, Db, Gb, min_common=1, tofile=True):
         A1.write_ion_areas_csv(expr_dir + output_prefix + 'aligned_ions.csv')
     return A1
 
-
+@jit
 def identify_peak(expr, peaknum):
     pl = expr.get_peak_list()
     ms = pl[peaknum].get_mass_spectrum()
@@ -348,7 +358,7 @@ def identify_peak(expr, peaknum):
 #            #print peak.get_rt()/60, ions
 #            ms = peak.get_mass_spectrum()
 #            print peak.get_rt()/60, output_golm_ms(ms)
-
+@jit
 def write_peak_ions_csv(expr):
     pl = expr.get_peak_list()
 
@@ -358,14 +368,14 @@ def write_peak_ions_csv(expr):
         ions = peak.peak_top_ion_areas()
         print rt / 60, ions
 
-
+@jit
 def list_peaks(expr, peak_list=None):
     if expr != None:
         peak_list = expr.get_peak_list()
     for peak in peak_list:
         print peak.get_rt() / 60, peak.get_area()
 
-
+@jit
 def peak_area_range(expr_list):
     peakareas = list()
     for expr in expr_list:
@@ -379,7 +389,7 @@ def peak_area_range(expr_list):
 
 from itertools import chain, izip
 
-
+@jit
 def output_golm_ms(ms):
     a1 = ms.mass_list
     a2 = (ms.mass_spec).tolist()
@@ -389,6 +399,7 @@ def output_golm_ms(ms):
 
 # returns a list of filenames prefix<START> to prefix<STOP>
 import random
+@jit
 def generate_runlist(prefix, first, last, randomize=False):
     l = []
     for i in range(first, last + 1):
@@ -398,7 +409,7 @@ def generate_runlist(prefix, first, last, randomize=False):
         random.shuffle(l)
     return l
 
-
+@jit
 def chunks(l, n):
     """ Yield successive n-sized chunks from l.
     """

--- a/pyms/Peak/Class.py
+++ b/pyms/Peak/Class.py
@@ -126,7 +126,7 @@ class Peak:
                     best = mass_spec[ii]
                     best2_ii = best_ii
                     best_ii = ii
-            ratio = int((100*mass_spec[best2_ii]/best)+1) - 1  #added +1 and -1 to avoid conversion error for NaN to int 
+            ratio = int(100*mass_spec[best2_ii]/(best+1))   #JT: added +1 to avoid divide by 0 error.
             UID = "%d-%d-%d-%.3f" % (int(mass_list[best_ii]),
                     int(mass_list[best2_ii]), ratio, self.__rt/minutes)
         elif self.__ic_mass != None:

--- a/pyms/Peak/Class.py
+++ b/pyms/Peak/Class.py
@@ -30,6 +30,8 @@ from pyms.Utils.Error import error
 from pyms.Utils.Utils import is_int, is_number, is_list, is_boolean, is_str
 from pyms.Utils.IO import open_for_writing, close_for_writing
 
+from numba import jit
+
 class Peak:
 
     """
@@ -42,7 +44,7 @@ class Peak:
     @author: Vladimir Likic
     @author: Andrew Isaac
     """
-
+    @jit
     # DK: added the is_outlier flag
     def __init__(self, rt=0.0, ms=None, minutes=False, outlier=False):
 
@@ -100,7 +102,7 @@ class Peak:
 
         # TEST: to test if this speeds things up
         self.rt = self.__rt
-
+    @jit
     def make_UID(self):
 
         """
@@ -135,7 +137,7 @@ class Peak:
             UID =  "%.3f" % self.__rt/minutes
 
         self.__UID = UID
-
+    @jit
     def get_UID(self):
 
         """
@@ -150,7 +152,7 @@ class Peak:
         """
 
         return self.__UID
-
+    @jit
     def get_third_highest_mz(self):
 
         """
@@ -179,7 +181,7 @@ class Peak:
 
         return int(mass_list[best3_ii])
     
-    
+    @jit 
     def set_pt_bounds(self, pt_bounds):
 
         """
@@ -204,7 +206,7 @@ class Peak:
                     error("'pt_bounds' element not an integer")
 
         self.__pt_bounds = pt_bounds
-
+    @jit
     def get_pt_bounds(self):
 
         """
@@ -218,7 +220,7 @@ class Peak:
         """
 
         return copy.deepcopy(self.__pt_bounds)
-
+    @jit
     def get_area(self):
 
         """
@@ -231,7 +233,7 @@ class Peak:
         """
 
         return self.__area
-
+    @jit
     def set_area(self, area):
 
         """
@@ -253,7 +255,7 @@ class Peak:
             print "'area' must be a positive number" #JT: changed from errror to print warning to console
             area = 1                                 #JT: set area to 1 to make it positive.
         self.__area = area
-        
+    @jit    
     def get_ion_area(self, ion):
         """
         @summary: gets the area of a single ion chromatogram
@@ -269,7 +271,7 @@ class Peak:
             return self.__ion_areas[ion]
         except KeyError:
             return None
-            
+    @jit        
     def get_ion_areas(self):
         """
         @summary: returns a copy of the ion areas dict
@@ -282,7 +284,7 @@ class Peak:
 
         return copy.deepcopy(self.__ion_areas)
 
-    
+    @jit
     def set_ion_area(self, ion, area):
         """
         @summary: sets the area for a single ion
@@ -294,7 +296,7 @@ class Peak:
         """
 
         self.__ion_areas[ion] = area
-
+    @jit
     def set_ion_areas(self, ion_areas):
         """
         @summary: set the ion:ion area pair dictionary
@@ -304,7 +306,7 @@ class Peak:
         """
 
         self.__ion_areas = ion_areas
-        
+    @jit    
     def get_int_of_ion(self, ion):
         """
         @summary: returns the intensity of a given ion
@@ -326,7 +328,7 @@ class Peak:
             intensity = None
 
         return intensity
-        
+    @jit   
     def set_ic_mass(self, mz):
 
         """
@@ -349,7 +351,7 @@ class Peak:
 
         # TEST: to test if this speeds things up
         self.mass_spec = None
-
+    @jit
     def set_mass_spectrum(self, ms):
 
         """
@@ -373,7 +375,7 @@ class Peak:
 
         # TEST: to test if this speeds things up
         self.mass_spec = ms.mass_spec
-
+    @jit
     def get_rt(self):
 
         """
@@ -384,7 +386,7 @@ class Peak:
         """
 
         return self.__rt
-
+    @jit
     def get_ic_mass(self):
 
         """
@@ -395,7 +397,7 @@ class Peak:
         """
 
         return self.__ic_mass
-
+    @jit
     def get_mass_spectrum(self):
 
         """
@@ -406,7 +408,7 @@ class Peak:
         """
 
         return copy.deepcopy(self.__mass_spectrum)
-
+    @jit
 ## TODO: What is this?
     def find_mass_spectrum(self, data, from_bounds=False):
 
@@ -449,7 +451,7 @@ class Peak:
 
         # TEST: to test if this speeds things up
         self.mass_spec = self.__mass_spectrum.mass_spec
-
+    @jit
     def crop_mass(self, mass_min, mass_max):
 
         """
@@ -503,7 +505,7 @@ class Peak:
 
         # TEST: to test if this speeds things up
         self.mass_spec = self.__mass_spectrum.mass_spec
-
+    @jit
     def null_mass(self, mass):
 
         """
@@ -542,7 +544,7 @@ class Peak:
 
         # TEST: to test if this speeds things up
         self.mass_spec = self.__mass_spectrum.mass_spec
-
+    @jit
     # DK
     def check_outlier(self):
         return self.isoutlier

--- a/pyms/Peak/Class.py
+++ b/pyms/Peak/Class.py
@@ -242,10 +242,16 @@ class Peak:
 
         @author: Andrew Isaac
         """
-
+        
+        """
+        JT: I was getting several peaks with area <=0 that kept closing the program.
+            I made an adjustment to set area to 1 if the error occurs, so I could continue
+            to debug the program and evaluate its output.
+        """    
+        
         if not is_number(area) or area <= 0:
-            error("'area' must be a positive number")
-
+            print "'area' must be a positive number" #JT: changed from errror to print warning to console
+            area = 1                                 #JT: set area to 1 to make it positive.
         self.__area = area
         
     def get_ion_area(self, ion):

--- a/pyms/Peak/Class.py
+++ b/pyms/Peak/Class.py
@@ -126,7 +126,7 @@ class Peak:
                     best = mass_spec[ii]
                     best2_ii = best_ii
                     best_ii = ii
-            ratio = int(100*mass_spec[best2_ii]/best)
+            ratio = int((100*mass_spec[best2_ii]/best)+1) - 1  #added +1 and -1 to avoid conversion error for NaN to int 
             UID = "%d-%d-%d-%.3f" % (int(mass_list[best_ii]),
                     int(mass_list[best2_ii]), ratio, self.__rt/minutes)
         elif self.__ic_mass != None:


### PR DESCRIPTION
I'm getting numerous peaks with zero area  in the set_area() function and divide by zero errors in the make_uid() function.  Also the TIC noise is being reported as 0. 

Have you ever run into these errors before? I made a few changes below, so I could keep working with the code and testing it.

I'm using netCDF formatted data pulled from a Leco TOF instrument. I exported the data with SN threshold = 50 and datapoint threshold = 100. I'm wondering if that or my peakcall parameters have something to do with it. 